### PR TITLE
Add Italian list of words.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/LilithHafner/WordLists.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/LilithHafner/WordLists.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/LilithHafner/WordLists.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/LilithHafner/WordLists.jl)
 
-WordLists.jl provides lists of words from various languages (currently English, French, Portuguese and Spanish).
+WordLists.jl provides lists of words from various languages (currently English, French, Italian, Portuguese and Spanish).
 
 ```julia-repl
 julia> words("English")
@@ -26,6 +26,4 @@ julia> words("English")
 
 ## Help Wanted
 
-The current set of languages is small and the list of French, Spanish and Portuguese words is incomplete. If you
-have access to a higher quality list of French, Spanish and Portuguese words or words from a different language,
-please open a pull request or issue.
+The current set of languages is small and the list of French, Italian, Spanish and Portuguese words is incomplete. If you have access to a higher quality list of French, Italian, Spanish and Portuguese words or words from a different language, please open a pull request or issue.

--- a/src/WordLists.jl
+++ b/src/WordLists.jl
@@ -33,6 +33,7 @@ The following languages are currently supported:
 - Spanish: "spanish", "español", "spa", "es"
 - Portuguese: "portuguese", "português", "por", "pt"
 - French: "french", "français", "fre", "fr"
+- Italian: "italian", "italiano", "ita", "it"
 
 Multilingual lists are supported. For example, `words("english", "spanish")` will return a
 sorted list containing words from both English and Spanish.
@@ -101,7 +102,11 @@ const LOOKUP_TABLE = Dict(
     "français" => "fr",
     "fre" => "fr",
     "fra" => "fr",
-    "fr" => "fr"
+    "fr" => "fr",
+    "italian" => "it",
+    "italiano" => "it",
+    "ita" => "it",
+    "it" => "it"
 )
 
 function combine_sorted!(lists::AbstractVector{<:AbstractVector})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ end
     @test words("spanish") isa Vector{String}
     @test words("portuguese") isa Vector{String}
     @test words("french") isa Vector{String}
+    @test words("italian") isa Vector{String}
 end
 
 @testset "Aliases" begin
@@ -20,6 +21,7 @@ end
     @test words("spanish") == words("es") == words("spa") == words("español")
     @test words("portuguese") == words("pt") == words("por") == words("português")
     @test words("french") == words("fr") == words("fre") == words("fra") == words("français")
+    @test words("italian") == words("it") == words("ita") == words("italiano")
 end
 
 @testset "Duplicate removal" begin
@@ -32,10 +34,11 @@ end
     @test words("spanish") == words("spanish"; all=true) # handle missing extra.txt
     @test words("portuguese") == words("portuguese"; all=true)
     @test words("french") == words("french"; all=true)
+    @test words("italian") == words("italian"; all=true)
 end
 
 @testset "Multilingual" begin
-    @test words("en") ⊊ words("english", "spanish", "portuguese", "french")
+    @test words("en") ⊊ words("english", "spanish", "portuguese", "french", "italian")
 end
 
 @testset "Error messages" begin
@@ -45,7 +48,7 @@ end
 
 @testset "Content" begin
     @testset "Formatting" begin
-        for langs in [("english",), ("spanish",), ("portuguese",), ("french",), ("english", "spanish", "portuguese","french")], all in [false, true]
+        for langs in [("english",), ("spanish",), ("portuguese",), ("french",), ("italian",), ("english", "spanish", "portuguese", "french", "italian")], all in [false, true]
             list = words(langs...; all)
             @test issorted(list)
             @test !any(word -> any(isspace, word), list) # No word contains whitespace
@@ -107,15 +110,29 @@ end
 
     @testset "French Content" begin
         fr = words("fr")
-        for word in ["merci","français","fille","garçon","beau","belle","jour",
-                     "demain","amour","pas","je","ne","plus","petit","grand",
-                     "désolé","comme","son","il","était","sur","sont","avec"]
+        for word in ["merci", "français", "fille", "garçon", "beau", "belle", "jour",
+            "demain", "amour", "pas", "je", "ne", "plus", "petit", "grand",
+            "désolé", "comme", "son", "il", "était", "sur", "sont", "avec"]
             @test word ∈ fr
         end
         for word in ["levantate", "hi", "pear", "lkfjakljf", "the", "of",
             "and", "to", "it", "with", "his", "that", "this", "from",
             "by", "was", "were", "são", "estão"]
             @test word ∉ fr
+        end
+    end
+
+    @testset "Italian Content" begin
+        it = words("it")
+        for word in ["grazie", "italiana", "ragazza", "bambino", "bella", "vero",
+            "giorno", "domani", "amore", "ci", "ne", "non", "più", "piccolo",
+            "grande", "scusa", "mi", "piace", "suo", "lui", "era", "su", "sono"]
+            @test word ∈ it
+        end
+        for word in ["levantate", "hi", "pear", "lkfjakljf", "the", "of",
+            "and", "to", "it", "with", "his", "that", "this", "from",
+            "by", "was", "were", "são", "estão", "avec"]
+            @test word ∉ it
         end
     end
 end


### PR DESCRIPTION
I added a Italian list of words with the lists from the [wikwik](https://it.wikwik.org/tutteleparole.htm) and [listediparole](https://www.listediparole.it/tutteleparole.htm) sites.

I also changed src/WordLists.jl and test/runtests.jl to support the Italian language.

Finally, I updated the Readme file to include Italian.