### PR TITLE
Adding German list of words

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/LilithHafner/WordLists.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/LilithHafner/WordLists.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/LilithHafner/WordLists.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/LilithHafner/WordLists.jl)
 
-WordLists.jl provides lists of words from various languages (currently English, French, Italian, Portuguese and Spanish).
+WordLists.jl provides lists of words from various languages (currently English, French, German, Italian, Portuguese and Spanish).
 
 ```julia-repl
 julia> words("English")
@@ -26,4 +26,4 @@ julia> words("English")
 
 ## Help Wanted
 
-The current set of languages is small and the list of French, Italian, Spanish and Portuguese words is incomplete. If you have access to a higher quality list of French, Italian, Spanish and Portuguese words or words from a different language, please open a pull request or issue.
+The current set of languages is small and the list of French, German, Italian, Spanish and Portuguese words is incomplete. If you have access to a higher quality list of French, German, Italian, Spanish and Portuguese words or words from a different language, please open a pull request or issue.

--- a/src/WordLists.jl
+++ b/src/WordLists.jl
@@ -34,6 +34,7 @@ The following languages are currently supported:
 - Portuguese: "portuguese", "português", "por", "pt"
 - French: "french", "français", "fre", "fr"
 - Italian: "italian", "italiano", "ita", "it"
+- German: "german", "deutsch", "deu", "de"
 
 Multilingual lists are supported. For example, `words("english", "spanish")` will return a
 sorted list containing words from both English and Spanish.
@@ -106,7 +107,11 @@ const LOOKUP_TABLE = Dict(
     "italian" => "it",
     "italiano" => "it",
     "ita" => "it",
-    "it" => "it"
+    "it" => "it",
+    "german" => "de",
+    "deutsch" => "de",
+    "deu" => "de",
+    "de" => "de"
 )
 
 function combine_sorted!(lists::AbstractVector{<:AbstractVector})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ end
     @test words("portuguese") isa Vector{String}
     @test words("french") isa Vector{String}
     @test words("italian") isa Vector{String}
+    @test words("german") isa Vector{String}
 end
 
 @testset "Aliases" begin
@@ -22,6 +23,7 @@ end
     @test words("portuguese") == words("pt") == words("por") == words("português")
     @test words("french") == words("fr") == words("fre") == words("fra") == words("français")
     @test words("italian") == words("it") == words("ita") == words("italiano")
+    @test words("german") == words("de") == words("deu") == words("deutsch")
 end
 
 @testset "Duplicate removal" begin
@@ -35,10 +37,11 @@ end
     @test words("portuguese") == words("portuguese"; all=true)
     @test words("french") == words("french"; all=true)
     @test words("italian") == words("italian"; all=true)
+    @test words("german") == words("german"; all=true)
 end
 
 @testset "Multilingual" begin
-    @test words("en") ⊊ words("english", "spanish", "portuguese", "french", "italian")
+    @test words("en") ⊊ words("english", "spanish", "portuguese", "french", "italian", "german")
 end
 
 @testset "Error messages" begin
@@ -48,7 +51,7 @@ end
 
 @testset "Content" begin
     @testset "Formatting" begin
-        for langs in [("english",), ("spanish",), ("portuguese",), ("french",), ("italian",), ("english", "spanish", "portuguese", "french", "italian")], all in [false, true]
+        for langs in [("english",), ("spanish",), ("portuguese",), ("french",), ("italian",), ("german",), ("english", "spanish", "portuguese", "french", "italian", "german")], all in [false, true]
             list = words(langs...; all)
             @test issorted(list)
             @test !any(word -> any(isspace, word), list) # No word contains whitespace
@@ -133,6 +136,20 @@ end
             "and", "to", "it", "with", "his", "that", "this", "from",
             "by", "was", "were", "são", "estão", "avec"]
             @test word ∉ it
+        end
+    end
+
+    @testset "German Content" begin
+        de = words("de")
+        for word in ["können", "dürfen", "mögen", "ich", "bin", "müssen", "Frau",
+            "sollen", "haben", "sein", "wurden", "bis", "durch", "für", "morgen",
+            "aus", "bevor", "wie", "ab", "Sie", "worauf", "du", "Tag", "was"]
+            @test word ∈ de
+        end
+        for word in ["levantate", "pear", "lkfjakljf", "the", "of",
+            "and", "to", "with", "that", "this", "from",
+            "by", "were", "são", "estão", "avec"]
+            @test word ∉ de
         end
     end
 end


### PR DESCRIPTION
I added a German list of words with the lists from the [wikwik](https://de.wikwik.org/alleworter.htm) and [wortlisten](https://www.wortlisten.com/alleworter.htm) sites.

I also changed src/WordLists.jl and test/runtests.jl to support the German language.

Finally, I updated the Readme file to include German.